### PR TITLE
QA Replace all gwt dependencies with official com.google.gwt artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,10 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.gwt</groupId>
+      <artifactId>gwt-elemental</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-server</artifactId>
       <version>7.7.0.alpha3</version>
@@ -82,6 +86,10 @@
         <exclusion>
           <groupId>com.vaadin.external.gwt</groupId>
           <artifactId>gwt-user</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.vaadin.external.gwt</groupId>
+          <artifactId>gwt-elemental</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
Looking at the dependency tree we found that there was one (out of three) vaading gwt artifact left `com.vaadin.external.gwtcom.vaadin.external.gwt:gwt-elemental`.  Wouldn't it make sense to replace all of them?
